### PR TITLE
TD-578: Removes unnecessary error_type

### DIFF
--- a/src/payproc_errors.erl
+++ b/src/payproc_errors.erl
@@ -20,7 +20,7 @@
 
 %%
 
--type error_type() :: 'PaymentFailure' | 'RefundFailure' | 'PreAuthorizationFailure'.
+-type error_type() :: 'PaymentFailure' | 'RefundFailure'.
 -type type() :: atom().
 -type reason() :: binary().
 


### PR DESCRIPTION
`PreAuthorizationFailure` is in union `PaymentFailure`